### PR TITLE
implement-interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,8 @@ namespace App\Models;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Vkovic\LaravelModelMeta\Models\Traits\HasMetadata;
-use Vkovic\LaravelModelMeta\Models\Interfaces\HasMetadataInterface;
 
-class User extends Authenticatable implements HasMetadataInterface // <= interface is added here
+class User extends Authenticatable
 {
     use Notifiable, HasMetadata; // <= trait is added here
 
@@ -175,6 +174,31 @@ User::whereHasMetaKey(['company', 'role'])->get();
 
 // All of the examples above will return Collection of users which meet's criteria,
 // in this case our $user and $anotherUser
+```
+
+## Check if model has metadata
+
+If you need to check if model has metadata functionality, you can implement an interface that comes with the package
+like: 
+
+```php
+namespace App\Models;
+
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Vkovic\LaravelModelMeta\Models\Interfaces\HasMetadataInterface;
+
+class User extends Authenticatable implements HasMetadataInterface // <= interface is added here
+{
+    // ...
+}
+```
+
+Implementing `HasMetadataInterface` gives us possibility to check if our model has metadata functionality implemented. 
+
+```php
+if ($model instanceof HasMetadataInterface) {
+    // ... do something
+}
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ namespace App\Models;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Vkovic\LaravelModelMeta\Models\Traits\HasMetadata;
+use Vkovic\LaravelModelMeta\Models\Interfaces\HasMetadataInterface;
 
-class User extends Authenticatable
+class User extends Authenticatable implements HasMetadataInterface // <= interface is added here
 {
     use Notifiable, HasMetadata; // <= trait is added here
 

--- a/src/package/Models/Interfaces/HasMetadataInterface.php
+++ b/src/package/Models/Interfaces/HasMetadataInterface.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Vkovic\LaravelModelMeta\Models\Interfaces;
+
+use Vkovic\LaravelModelMeta\Models\Meta;
+
+interface HasMetadataInterface
+{
+    /**
+     * Initialize the trait
+     *
+     * @return void
+     */
+    public static function bootHasMetaData();
+
+    /**
+     * Morph many relation
+     *
+     * @return MorphMany
+     */
+    public function meta();
+
+    /**
+     * Set meta at given key
+     * related to this model (via metable)
+     * for package realm.
+     * If meta exists, it'll be overwritten.
+     *
+     * @param string $key
+     * @param mixed  $value
+     */
+    public function setMeta($key, $value);
+
+    /**
+     * Create meta at given key
+     * related to this model (via metable)
+     * for package realm.
+     * If meta exists, exception will be thrown.
+     *
+     * @param string $key
+     * @param mixed  $value
+     *
+     * @throws \Exception
+     */
+    public function createMeta($key, $value);
+
+    /**
+     * Update meta at given key
+     * related to this model (via metable)
+     * for package realm.
+     * If meta doesn't exists, exception will be thrown.
+     *
+     * @param string $key
+     * @param mixed  $value
+     *
+     * @throws \Exception
+     */
+    public function updateMeta($key, $value);
+
+    /**
+     * Get meta at given key
+     * related to this model (via metable)
+     * for package realm
+     *
+     * @param string $key
+     * @param mixed  $default
+     *
+     * @return array
+     */
+    public function getMeta($key, $default = null);
+
+    /**
+     * Check if meta key record exists by given key
+     * related to this model (via metable)
+     * for package realm
+     *
+     * @param string $key
+     *
+     * @return bool
+     */
+    public function metaExists($key);
+
+    /**
+     * Count all meta
+     * related to this model (via metable)
+     * for package realm
+     *
+     * @param string $realm
+     *
+     * @return int
+     */
+    public function countMeta();
+
+    /**
+     * Get all meta
+     * related to this model (via metable)
+     * for package realm
+     *
+     * @return array
+     */
+    public function allMeta();
+
+    /**
+     * Get all meta keys
+     * related to this model (via metable)
+     * for package realm
+     *
+     * @return array
+     */
+    public function metaKeys();
+
+    /**
+     * Remove meta at given key or array of keys
+     * related to this model (via metable)
+     * for package realm
+     *
+     * @param string|array $key
+     */
+    public function removeMeta($key);
+
+    /**
+     * Purge meta
+     * related to this model (via metable)
+     * for package realm
+     *
+     * @return int Number of records deleted
+     */
+    public function purgeMeta();
+}

--- a/src/package/Models/Interfaces/HasMetadataInterface.php
+++ b/src/package/Models/Interfaces/HasMetadataInterface.php
@@ -2,24 +2,8 @@
 
 namespace Vkovic\LaravelModelMeta\Models\Interfaces;
 
-use Vkovic\LaravelModelMeta\Models\Meta;
-
 interface HasMetadataInterface
 {
-    /**
-     * Initialize the trait
-     *
-     * @return void
-     */
-    public static function bootHasMetaData();
-
-    /**
-     * Morph many relation
-     *
-     * @return MorphMany
-     */
-    public function meta();
-
     /**
      * Set meta at given key
      * related to this model (via metable)
@@ -27,7 +11,7 @@ interface HasMetadataInterface
      * If meta exists, it'll be overwritten.
      *
      * @param string $key
-     * @param mixed  $value
+     * @param mixed $value
      */
     public function setMeta($key, $value);
 
@@ -38,7 +22,7 @@ interface HasMetadataInterface
      * If meta exists, exception will be thrown.
      *
      * @param string $key
-     * @param mixed  $value
+     * @param mixed $value
      *
      * @throws \Exception
      */
@@ -51,7 +35,7 @@ interface HasMetadataInterface
      * If meta doesn't exists, exception will be thrown.
      *
      * @param string $key
-     * @param mixed  $value
+     * @param mixed $value
      *
      * @throws \Exception
      */
@@ -63,7 +47,7 @@ interface HasMetadataInterface
      * for package realm
      *
      * @param string $key
-     * @param mixed  $default
+     * @param mixed $default
      *
      * @return array
      */

--- a/src/package/Models/Traits/HasMetadata.php
+++ b/src/package/Models/Traits/HasMetadata.php
@@ -14,22 +14,12 @@ trait HasMetadata
      *
      * @return void
      */
-    public static function bootHasMetaData()
+    public static function bootHasMetaData(): void
     {
         // Delete related meta on model deletion
         static::deleted(function (HasMetadataInterface $model) {
             $model->purgeMeta();
         });
-    }
-
-    /**
-     * Morph many relation
-     *
-     * @return MorphMany
-     */
-    public function meta()
-    {
-        return $this->morphMany(Meta::class, 'metable');
     }
 
     /**
@@ -39,11 +29,13 @@ trait HasMetadata
      * If meta exists, it'll be overwritten.
      *
      * @param string $key
-     * @param mixed  $value
+     * @param mixed $value
+     *
+     * @return void
      */
-    public function setMeta($key, $value)
+    public function setMeta($key, $value): void
     {
-        /** @var \Vkovic\LaravelModelMeta\Models\Interfaces\HasMetadataInterface; $this */
+        /** @var HasMetadataInterface; $this */
         $meta = Meta::metable(static::class, $this->id)
             ->where('key', $key)->first();
 
@@ -58,19 +50,30 @@ trait HasMetadata
     }
 
     /**
+     * Morph many relation
+     *
+     * @return MorphMany
+     */
+    public function meta(): MorphMany
+    {
+        return $this->morphMany(Meta::class, 'metable');
+    }
+
+    /**
      * Create meta at given key
      * related to this model (via metable)
      * for package realm.
      * If meta exists, exception will be thrown.
      *
      * @param string $key
-     * @param mixed  $value
+     * @param mixed $value
      *
+     * @return void
      * @throws \Exception
      */
-    public function createMeta($key, $value)
+    public function createMeta($key, $value): void
     {
-        /** @var \Vkovic\LaravelModelMeta\Models\Interfaces\HasMetadataInterface; $this */
+        /** @var HasMetadataInterface $this */
         $exists = Meta::metable(static::class, $this->id)
             ->where('key', $key)->exists();
 
@@ -95,14 +98,15 @@ trait HasMetadata
      * If meta doesn't exists, exception will be thrown.
      *
      * @param string $key
-     * @param mixed  $value
+     * @param mixed $value
      *
+     * @return void
      * @throws \Exception
      */
-    public function updateMeta($key, $value)
+    public function updateMeta($key, $value): void
     {
         try {
-            /** @var \Vkovic\LaravelModelMeta\Models\Interfaces\HasMetadataInterface; $this */
+            /** @var HasMetadataInterface $this */
             $meta = Meta::metable(static::class, $this->id)
                 ->where('key', $key)->firstOrFail();
         } catch (\Exception $e) {
@@ -123,13 +127,13 @@ trait HasMetadata
      * for package realm
      *
      * @param string $key
-     * @param mixed  $default
+     * @param mixed $default
      *
-     * @return array
+     * @return mixed
      */
     public function getMeta($key, $default = null)
     {
-        /** @var \Vkovic\LaravelModelMeta\Models\Interfaces\HasMetadataInterface; $this */
+        /** @var HasMetadataInterface $this */
         $meta = Meta::metable(static::class, $this->id)
             ->where('key', $key)->first();
 
@@ -147,9 +151,9 @@ trait HasMetadata
      *
      * @return bool
      */
-    public function metaExists($key)
+    public function metaExists($key): bool
     {
-        /** @var \Vkovic\LaravelModelMeta\Models\Interfaces\HasMetadataInterface; $this */
+        /** @var HasMetadataInterface $this */
         return Meta::metable(static::class, $this->id)
             ->where('key', $key)->exists();
     }
@@ -161,9 +165,9 @@ trait HasMetadata
      *
      * @return int
      */
-    public function countMeta()
+    public function countMeta(): int
     {
-        /** @var \Vkovic\LaravelModelMeta\Models\Interfaces\HasMetadataInterface; $this */
+        /** @var HasMetadataInterface $this */
         return Meta::metable(static::class, $this->id)
             ->count();
     }
@@ -175,9 +179,9 @@ trait HasMetadata
      *
      * @return array
      */
-    public function allMeta()
+    public function allMeta(): array
     {
-        /** @var \Vkovic\LaravelModelMeta\Models\Interfaces\HasMetadataInterface; $this */
+        /** @var HasMetadataInterface $this */
         $meta = Meta::metable(static::class, $this->id)
             ->get(['key', 'value', 'type']);
 
@@ -196,9 +200,9 @@ trait HasMetadata
      *
      * @return array
      */
-    public function metaKeys()
+    public function metaKeys(): array
     {
-        /** @var \Vkovic\LaravelModelMeta\Models\Interfaces\HasMetadataInterface; $this */
+        /** @var HasMetadataInterface $this */
         return Meta::metable(static::class, $this->id)
             ->pluck('key')
             ->toArray();
@@ -210,13 +214,15 @@ trait HasMetadata
      * for package realm
      *
      * @param string|array $key
+     *
+     * @return int Number of records deleted
      */
-    public function removeMeta($key)
+    public function removeMeta($key): int
     {
         $keys = (array) $key;
 
-        /** @var \Vkovic\LaravelModelMeta\Models\Interfaces\HasMetadataInterface; $this */
-        Meta::metable(static::class, $this->id)
+        /** @var HasMetadataInterface $this */
+        return Meta::metable(self::class, $this->id)
             ->whereIn('key', $keys)
             ->delete();
     }
@@ -228,9 +234,9 @@ trait HasMetadata
      *
      * @return int Number of records deleted
      */
-    public function purgeMeta()
+    public function purgeMeta(): int
     {
-        /** @var \Vkovic\LaravelModelMeta\Models\Interfaces\HasMetadataInterface; $this */
+        /** @var HasMetadataInterface $this */
         return Meta::metable(static::class, $this->id)
             ->delete();
     }
@@ -242,16 +248,15 @@ trait HasMetadata
     /**
      * Filter all models by providing meta data
      *
-     * @param Builder    $query
-     * @param string     $key
-     * @param string     $operator
+     * @param Builder $query
+     * @param string $key
+     * @param string $operator
      * @param null|mixed $value
      *
      * @return Builder
-     *
      * @throws \Exception
      */
-    public function scopeWhereMeta(Builder $query, $key, $operator, $value = null)
+    public function scopeWhereMeta(Builder $query, $key, $operator, $value = null): Builder
     {
         // If there is no value, it means operator is value
         if ($value === null) {
@@ -261,7 +266,7 @@ trait HasMetadata
 
         // Prevent invalid operators
         $validOperators = ['<', '<=', '>', '>=', '=', '<>', '!='];
-        if (!in_array($operator, $validOperators)) {
+        if (! in_array($operator, $validOperators)) {
             throw new \Exception('Invalid operator. Allowed: ' . implode(', ', $validOperators));
         }
 
@@ -287,11 +292,11 @@ trait HasMetadata
      * Filter all models which meta contains given key
      *
      * @param Builder $query
-     * @param string  $key
+     * @param string $key
      *
      * @return Builder
      */
-    public function scopeWhereHasMetaKey(Builder $query, $key)
+    public function scopeWhereHasMetaKey(Builder $query, $key): Builder
     {
         return $query->whereHas('meta', function (Builder $q) use ($key) {
             $q->whereIn('key', (array) $key);

--- a/src/package/Models/Traits/HasMetadata.php
+++ b/src/package/Models/Traits/HasMetadata.php
@@ -3,8 +3,8 @@
 namespace Vkovic\LaravelModelMeta\Models\Traits;
 
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Vkovic\LaravelModelMeta\Models\Interfaces\HasMetadataInterface;
 use Vkovic\LaravelModelMeta\Models\Meta;
 
 trait HasMetadata
@@ -17,7 +17,7 @@ trait HasMetadata
     public static function bootHasMetaData()
     {
         // Delete related meta on model deletion
-        static::deleted(function (Model $model) {
+        static::deleted(function (HasMetadataInterface $model) {
             $model->purgeMeta();
         });
     }
@@ -43,7 +43,7 @@ trait HasMetadata
      */
     public function setMeta($key, $value)
     {
-        /** @var Model $this */
+        /** @var \Vkovic\LaravelModelMeta\Models\Interfaces\HasMetadataInterface; $this */
         $meta = Meta::metable(static::class, $this->id)
             ->where('key', $key)->first();
 
@@ -70,7 +70,7 @@ trait HasMetadata
      */
     public function createMeta($key, $value)
     {
-        /** @var Model $this */
+        /** @var \Vkovic\LaravelModelMeta\Models\Interfaces\HasMetadataInterface; $this */
         $exists = Meta::metable(static::class, $this->id)
             ->where('key', $key)->exists();
 
@@ -102,7 +102,7 @@ trait HasMetadata
     public function updateMeta($key, $value)
     {
         try {
-            /** @var Model $this */
+            /** @var \Vkovic\LaravelModelMeta\Models\Interfaces\HasMetadataInterface; $this */
             $meta = Meta::metable(static::class, $this->id)
                 ->where('key', $key)->firstOrFail();
         } catch (\Exception $e) {
@@ -129,7 +129,7 @@ trait HasMetadata
      */
     public function getMeta($key, $default = null)
     {
-        /** @var Model $this */
+        /** @var \Vkovic\LaravelModelMeta\Models\Interfaces\HasMetadataInterface; $this */
         $meta = Meta::metable(static::class, $this->id)
             ->where('key', $key)->first();
 
@@ -149,7 +149,7 @@ trait HasMetadata
      */
     public function metaExists($key)
     {
-        /** @var Model $this */
+        /** @var \Vkovic\LaravelModelMeta\Models\Interfaces\HasMetadataInterface; $this */
         return Meta::metable(static::class, $this->id)
             ->where('key', $key)->exists();
     }
@@ -159,13 +159,11 @@ trait HasMetadata
      * related to this model (via metable)
      * for package realm
      *
-     * @param string $realm
-     *
      * @return int
      */
     public function countMeta()
     {
-        /** @var Model $this */
+        /** @var \Vkovic\LaravelModelMeta\Models\Interfaces\HasMetadataInterface; $this */
         return Meta::metable(static::class, $this->id)
             ->count();
     }
@@ -179,7 +177,7 @@ trait HasMetadata
      */
     public function allMeta()
     {
-        /** @var Model $this */
+        /** @var \Vkovic\LaravelModelMeta\Models\Interfaces\HasMetadataInterface; $this */
         $meta = Meta::metable(static::class, $this->id)
             ->get(['key', 'value', 'type']);
 
@@ -200,7 +198,7 @@ trait HasMetadata
      */
     public function metaKeys()
     {
-        /** @var Model $this */
+        /** @var \Vkovic\LaravelModelMeta\Models\Interfaces\HasMetadataInterface; $this */
         return Meta::metable(static::class, $this->id)
             ->pluck('key')
             ->toArray();
@@ -217,7 +215,7 @@ trait HasMetadata
     {
         $keys = (array) $key;
 
-        /** @var Model $this */
+        /** @var \Vkovic\LaravelModelMeta\Models\Interfaces\HasMetadataInterface; $this */
         Meta::metable(static::class, $this->id)
             ->whereIn('key', $keys)
             ->delete();
@@ -232,7 +230,7 @@ trait HasMetadata
      */
     public function purgeMeta()
     {
-        /** @var Model $this */
+        /** @var \Vkovic\LaravelModelMeta\Models\Interfaces\HasMetadataInterface; $this */
         return Meta::metable(static::class, $this->id)
             ->delete();
     }

--- a/src/package/Models/Traits/HasMetadata.php
+++ b/src/package/Models/Traits/HasMetadata.php
@@ -23,6 +23,16 @@ trait HasMetadata
     }
 
     /**
+     * Morph many relation
+     *
+     * @return MorphMany
+     */
+    public function meta(): MorphMany
+    {
+        return $this->morphMany(Meta::class, 'metable');
+    }
+
+    /**
      * Set meta at given key
      * related to this model (via metable)
      * for package realm.
@@ -47,16 +57,6 @@ trait HasMetadata
         $meta->value = $value;
 
         $this->meta()->save($meta);
-    }
-
-    /**
-     * Morph many relation
-     *
-     * @return MorphMany
-     */
-    public function meta(): MorphMany
-    {
-        return $this->morphMany(Meta::class, 'metable');
     }
 
     /**

--- a/src/package/Models/Traits/HasMetadata.php
+++ b/src/package/Models/Traits/HasMetadata.php
@@ -39,13 +39,13 @@ trait HasMetadata
      * If meta exists, it'll be overwritten.
      *
      * @param string $key
-     * @param mixed $value
+     * @param mixed  $value
      *
      * @return void
      */
     public function setMeta($key, $value): void
     {
-        /** @var HasMetadataInterface; $this */
+        /** @var HasMetadataInterface $this */
         $meta = Meta::metable(static::class, $this->id)
             ->where('key', $key)->first();
 
@@ -66,7 +66,7 @@ trait HasMetadata
      * If meta exists, exception will be thrown.
      *
      * @param string $key
-     * @param mixed $value
+     * @param mixed  $value
      *
      * @return void
      * @throws \Exception
@@ -98,7 +98,7 @@ trait HasMetadata
      * If meta doesn't exists, exception will be thrown.
      *
      * @param string $key
-     * @param mixed $value
+     * @param mixed  $value
      *
      * @return void
      * @throws \Exception
@@ -127,7 +127,7 @@ trait HasMetadata
      * for package realm
      *
      * @param string $key
-     * @param mixed $default
+     * @param mixed  $default
      *
      * @return mixed
      */
@@ -248,9 +248,9 @@ trait HasMetadata
     /**
      * Filter all models by providing meta data
      *
-     * @param Builder $query
-     * @param string $key
-     * @param string $operator
+     * @param Builder    $query
+     * @param string     $key
+     * @param string     $operator
      * @param null|mixed $value
      *
      * @return Builder
@@ -266,7 +266,7 @@ trait HasMetadata
 
         // Prevent invalid operators
         $validOperators = ['<', '<=', '>', '>=', '=', '<>', '!='];
-        if (! in_array($operator, $validOperators)) {
+        if (!in_array($operator, $validOperators)) {
             throw new \Exception('Invalid operator. Allowed: ' . implode(', ', $validOperators));
         }
 
@@ -292,7 +292,7 @@ trait HasMetadata
      * Filter all models which meta contains given key
      *
      * @param Builder $query
-     * @param string $key
+     * @param string  $key
      *
      * @return Builder
      */

--- a/tests/Integration/GetModelsThroughMetaTest.php
+++ b/tests/Integration/GetModelsThroughMetaTest.php
@@ -3,6 +3,7 @@
 namespace Vkovic\LaravelModelMeta\Test\Integration;
 
 use Illuminate\Support\Str;
+use Vkovic\LaravelModelMeta\Models\Interfaces\HasMetadataInterface;
 use Vkovic\LaravelModelMeta\Test\Support\Models\User;
 use Vkovic\LaravelModelMeta\Test\TestCase;
 
@@ -131,5 +132,13 @@ class GetModelsThroughMetaTest extends TestCase
         $this->expectExceptionMessage('Invalid operator');
 
         User::whereMeta('foo', '><', 'bar');
+    }
+
+    /**
+     * @test
+     */
+    public function trait_model_has_interface_type()
+    {
+        $this->assertTrue((new User) instanceof HasMetadataInterface);
     }
 }

--- a/tests/Support/Models/User.php
+++ b/tests/Support/Models/User.php
@@ -3,9 +3,10 @@
 namespace Vkovic\LaravelModelMeta\Test\Support\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Vkovic\LaravelModelMeta\Models\Interfaces\HasMetadataInterface;
 use Vkovic\LaravelModelMeta\Models\Traits\HasMetadata;
 
-class User extends Model
+class User extends Model implements HasMetadataInterface
 {
     use HasMetadata;
 


### PR DESCRIPTION
I suggest this `HasMetadataInterface` implementation, in order to :
- implement a contract
- be able to check if a model is an `HasMetadataInterface` type or not

For example, in a service, I take a model that implement your trait as a method parameter and I am currently not able to check if the model is implementing the trait or not. With the interface, this problem is fixed.